### PR TITLE
Faster implementation of Kendall tau distances

### DIFF
--- a/pref_voting/other_methods.py
+++ b/pref_voting/other_methods.py
@@ -86,12 +86,12 @@ def pareto(prof, curr_cands = None, strong_Pareto = False, use_extended_strict_p
 ## Kemeny-Young Method 
 #
 def kendalltau_dist(rank_a, rank_b):
-    rank_a = tuple(rank_a)
-    rank_b = tuple(rank_b)
+    index_b = {c: i for i, c in enumerate(rank_b)}
     tau = 0
-    candidates = sorted(rank_a)
-    for i, j in combinations(candidates, 2):
-        tau += (np.sign(rank_a.index(i) - rank_a.index(j)) == -np.sign(rank_b.index(i) - rank_b.index(j)))
+    for i, j in combinations(rank_a, 2):
+        # by definition of itertools.combinations, index_a[i] < index_a[j]
+        if index_b[i] > index_b[j]:
+            tau += 1
     return tau
 
 


### PR DESCRIPTION
One can speed up the computation (by about 10x) of KT distances by using the definition of itertools.combinations which respects the ordering of the iterator it is passed. See https://gist.github.com/DominikPeters/92abecfc7c1ee0396ef7b0d42c3c7685