### PR TITLE
Speed up instant runoff PUT by immediately eliminating score-0 candidates

### DIFF
--- a/pref_voting/iterative_methods.py
+++ b/pref_voting/iterative_methods.py
@@ -446,12 +446,15 @@ def bottom_two_runoff_instant_runoff(profile, curr_cands = None):
     if len(candidates) == 1:
         return candidates
 
-    cands_with_lowest_plurality_score = [cand for cand, value in profile.plurality_scores(candidates).items() if value == min(profile.plurality_scores(candidates).values())]
+    plurality_scores = profile.plurality_scores(candidates)
+    worst_score = min(plurality_scores.values())
+    cands_with_lowest_plurality_score = [cand for cand, value in plurality_scores.items() if value == worst_score]
 
     if len(cands_with_lowest_plurality_score) > 1:
         cands_with_second_lowest_plurality_score = cands_with_lowest_plurality_score
     else:
-        cands_with_second_lowest_plurality_score = [cand for cand, value in profile.plurality_scores(candidates).items() if value == sorted(profile.plurality_scores(candidates).values())[1]]
+        second_lowest_plurality_score = sorted(plurality_scores.values())[1]
+        cands_with_second_lowest_plurality_score = [cand for cand, value in plurality_scores.items() if value == second_lowest_plurality_score]
     
     cands_to_remove = []
 
@@ -487,12 +490,15 @@ def bottom_two_runoff_instant_runoff_put(profile, curr_cands = None):
     if len(candidates) == 1:
         return candidates
 
-    cands_with_lowest_plurality_score = [cand for cand, value in profile.plurality_scores(candidates).items() if value == min(profile.plurality_scores(candidates).values())]
+    plurality_scores = profile.plurality_scores(candidates)
+    worst_score = min(plurality_scores.values())
+    cands_with_lowest_plurality_score = [cand for cand, value in plurality_scores.items() if value == worst_score]
 
     if len(cands_with_lowest_plurality_score) > 1:
         cands_with_second_lowest_plurality_score = cands_with_lowest_plurality_score
     else:
-        cands_with_second_lowest_plurality_score = [cand for cand, value in profile.plurality_scores(candidates).items() if value == sorted(profile.plurality_scores(candidates).values())[1]]
+        second_lowest_plurality_score = sorted(plurality_scores.values())[1]
+        cands_with_second_lowest_plurality_score = [cand for cand, value in plurality_scores.items() if value == second_lowest_plurality_score]
     
     winners = []
 
@@ -1727,8 +1733,11 @@ def benham_put(profile, curr_cands = None):
     cw = profile.condorcet_winner(candidates)
     if cw is not None:
         return [cw]
+    
+    plurality_scores = profile.plurality_scores(candidates)
+    worst_score = min(plurality_scores.values())
 
-    cands_to_remove = [cand for cand, value in profile.plurality_scores(candidates).items() if value == min(profile.plurality_scores(candidates).values())]
+    cands_to_remove = [cand for cand, value in plurality_scores.items() if value == worst_score]
     
     winners = []
     for cand_to_remove in cands_to_remove:
@@ -1779,7 +1788,10 @@ def tideman_alternative(vm):
     
         vm_ws = vm(profile, curr_cands = candidates)
 
-        cands_to_remove = [cand for cand, value in profile.plurality_scores(vm_ws).items() if value == min(profile.plurality_scores(vm_ws).values())]
+        plurality_scores = profile.plurality_scores(vm_ws)
+        worst_score = min(plurality_scores.values())
+
+        cands_to_remove = [cand for cand, value in plurality_scores.items() if value == worst_score]
         
         if len(cands_to_remove) == len(vm_ws):
             return vm_ws
@@ -1813,7 +1825,9 @@ def tideman_alternative_put(vm):
             return vm_ws
     
         else: 
-            cands_to_remove = [cand for cand, value in profile.plurality_scores(vm_ws).items() if value == min(profile.plurality_scores(vm_ws).values())]
+            plurality_scores = profile.plurality_scores(vm_ws)
+            worst_score = min(plurality_scores.values())
+            cands_to_remove = [cand for cand, value in plurality_scores.items() if value == worst_score]
         
             winners = []
             for cand_to_remove in cands_to_remove:


### PR DESCRIPTION
When computing instant runoff PUT, it is safe to immediately eliminate all candidates that are never top-ranked, because every elimination order will start by eliminating those candidates (proof: clearly, the first candidate to be eliminated has score 0; because it has score 0, no votes get reassigned, so score-0 candidates remain score-0).

This leads to a large speed-up in profiles with many more candidates than voters.

I've also refactored some other parts of the code in iterative_methods, where plurality scores were sometimes needlessly repeatedly computed.